### PR TITLE
Fix override of Tracking for SpellProjectiles

### DIFF
--- a/src/main/java/elucent/eidolon/common/entity/SpellProjectileEntity.java
+++ b/src/main/java/elucent/eidolon/common/entity/SpellProjectileEntity.java
@@ -51,7 +51,7 @@ public abstract class SpellProjectileEntity extends Projectile {
     }
 
     private boolean shouldTrack(final Entity target) {
-        return !target.isSpectator() && !target.getUUID().equals(getOwnerUUID()) && !target.getType().is(TRACKABLE_BLACKLIST) && (target instanceof Enemy || target.getType().is(TRACKABLE));
+        return !target.isSpectator() && !target.getUUID().equals(getOwnerUUID()) && !target.getType().is(TRACKABLE_BLACKLIST);
     }
 
     @Override

--- a/src/main/java/elucent/eidolon/util/EntityUtil.java
+++ b/src/main/java/elucent/eidolon/util/EntityUtil.java
@@ -51,7 +51,7 @@ public class EntityUtil {
             owner = projectile.getOwner();
             Predicate<Entity> targetMode = projectile instanceof TargetMode mode ? mode.eidolonrepraised$getMode() : null;
             if (entity instanceof SpellProjectileEntity spellProjectile)
-                targetPredicate = spellProjectile.trackingPredicate;
+                targetPredicate = spellProjectile.trackingPredicate.and(targetMode);
             else targetPredicate = targetMode != null ? targetMode : /* Should not happen */ FALLBACK_TARGET_PREDICATE;
         } else {
             owner = null;


### PR DESCRIPTION
SpellProjectiles can target non hostile entities now. This is similar to normal projectiles.
No support for TRACKABLE list yet. Here a design decision has to be made. Should entities in the TRACKABLE list always be tracked no matter which mode was chosen?